### PR TITLE
Add mode parameter

### DIFF
--- a/tasks/install-file.yml
+++ b/tasks/install-file.yml
@@ -11,6 +11,7 @@
       Package: docker-compose
       Pin: version *
       Pin-Priority: -1
+    mode: 0644
     dest: /etc/apt/preferences.d/docker-compose
   become: true
 

--- a/tasks/install-package.yml
+++ b/tasks/install-package.yml
@@ -17,6 +17,7 @@
       Pin: release o=pbuilder
       Pin-Priority: 999
     dest: /etc/apt/preferences.d/docker-compose
+    mode: 0644
   become: true
   when: docker_compose_configure_repository|bool
 
@@ -26,6 +27,7 @@
     state: present
     filename: docker-compose
     update_cache: yes
+    mode: 0644
   become: true
   when: docker_compose_configure_repository|bool
 

--- a/tasks/install-url.yml
+++ b/tasks/install-url.yml
@@ -11,6 +11,7 @@
       Package: docker-compose
       Pin: version *
       Pin-Priority: -1
+    mode: 0644
     dest: /etc/apt/preferences.d/docker-compose
   become: true
 


### PR DESCRIPTION
[WARNING]: File 'xxx' created with default '600'. The previous default
was '666'. Specify 'mode' to avoid this warning.

Signed-off-by: Christian Berendt <berendt@betacloud-solutions.de>